### PR TITLE
Disable chatbot access for evaluator type 3

### DIFF
--- a/lib/structure/pages/login/login_page.dart
+++ b/lib/structure/pages/login/login_page.dart
@@ -53,6 +53,12 @@ class _LoginPageState extends State<LoginPage> {
     if (state is LoginSuccesState) {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString('userId', state.usuario!.id.toString());
+      final userTypeId = state.usuario!.userType?.id;
+      if (userTypeId != null) {
+        await prefs.setString('userTypeId', userTypeId.toString());
+      } else {
+        await prefs.remove('userTypeId');
+      }
       Navigator.of(context).pushAndRemoveUntil(
         MaterialPageRoute(builder: (_) => const MainPage()),
             (route) => false,


### PR DESCRIPTION
## Summary
- persist the logged-in user's type id in shared preferences during login
- gate the heuristics chatbot UI on evaluator user types, hiding it for type 3 evaluators

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_690c04188d8883259a1ef84385d6b459